### PR TITLE
Fix: Single-line comments will break IIFE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `Fixed` for any bug fixes
 -   `Security` in case of vulnerabilities
 
+## [UNRELEASED]
+
+### Fixed
+
+-   Comments on last line breaking script execution
+
 ## [0.3.0] - 2024-08-05
 
 ### Added

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -33,7 +33,7 @@ export async function post(data: Data) {
 
 export async function writeScript(doc: TextDocument) {
 	const text = doc.getText()
-	const script = `(function() { ${text} })()`
+	const script = `(function() { ${text} \n})()`
 	const saved = !doc.isUntitled
 	const showUI = text.includes('ui.show()')
 	let path = await temporaryWrite(script, { extension: 'js' })


### PR DESCRIPTION
In case the last line of the script is a single-line comment, add a newline character to the end to prevent the IIFE from breaking.